### PR TITLE
check for correct 'not running' message

### DIFF
--- a/run.bash
+++ b/run.bash
@@ -148,10 +148,10 @@ LAST_OK_DATE=`date +%s`
 #
 # Note that ossec-execd is never expected to run here.
 #
-STATUS_CMD="service ossec status | sed '/ossec-maild/d' | sed '/ossec-execd/d' | grep 'is not running' | test -z"
+STATUS_CMD="service ossec status | sed '/ossec-maild/d' | sed '/ossec-execd/d' | grep ' not running' | test -z"
 if [ $SMTP_ENABLED == true ]
 then
-  STATUS_CMD="/var/ossec/bin/ossec-control status | sed '/ossec-execd/d' | grep 'is not running' | test -z"
+  STATUS_CMD="/var/ossec/bin/ossec-control status | sed '/ossec-execd/d' | grep ' not running' | test -z"
 fi
 
 while true


### PR DESCRIPTION
when a process is not running, the output is:

```
# /var/ossec/bin/ossec-control status
ossec-monitord is running... 
ossec-logcollector is running...
ossec-remoted not running... 
ossec-syscheckd is running...
ossec-analysisd is running...
ossec-maild not running...   
ossec-execd is running...
ossec-csyslogd is running... 
```

note that it says '<daemon> not running' instead of '<daemon> is not running
