### PR TITLE
If you try to run agent-less need expect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER Terence Kent <tkent@xetus.com>
 #
 RUN apt-key adv --fetch-keys http://ossec.wazuh.com/repos/apt/conf/ossec-key.gpg.key &&\
   echo "deb http://ossec.wazuh.com/repos/apt/ubuntu trusty main" >> /etc/apt/sources.list &&\
-  apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -yf install ossec-hids \
+  apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -yf install expect ossec-hids \
   ossec-hids=2.8.3-4trusty
 
 #


### PR DESCRIPTION
If you try to add one agent-less without `expect` in your container, we obtain the following error
`ossec-agentlessd: ERROR: Expect command not found (or bad arguments) for 'ssh_generic_diff'.`
